### PR TITLE
Add pubs through to today

### DIFF
--- a/src/pubs.bib
+++ b/src/pubs.bib
@@ -11,6 +11,68 @@
 @string{asplos = {International Conference on Architectural Support for
     Programming Languages and Operating Systems (ASPLOS)}}
 @string{snapl = {Summit on Advances in Programming Languages (SNAPL)}}
+@string{icse-seip = {International Conference on Software Engineering: Software Engineering in Practice (ICSE SEIP)}}
+@string{hpca = {IEEE International Symposium on High-Performance Computer Architecture (HPCA)}}
+
+@inproceedings{DBLP:conf/asplos/VanHattumPFSB24,
+  author       = {Alexa VanHattum and
+                  Monica Pardeshi and
+                  Chris Fallin and
+                  Adrian Sampson and
+                  Fraser Brown},
+  title        = {Lightweight, Modular Verification for WebAssembly-to-Native Instruction
+                  Selection},
+  booktitle    = asplos,
+  year         = {2024},
+}
+
+@article{DBLP:journals/pacmpl/NigamAS23,
+  author       = {Rachit Nigam and
+                  Pedro Henrique Azevedo de Amorim and
+                  Adrian Sampson},
+  title        = {Modular Hardware Design with Timeline Types},
+  number       = pldi,
+  year         = {2023},
+}
+
+@inproceedings{DBLP:conf/asplos/BerlsteinNGS23,
+  author       = {Griffin Berlstein and
+                  Rachit Nigam and
+                  Christophe Gyurgyik and
+                  Adrian Sampson},
+  title        = {Stepwise Debugging for Hardware Accelerators},
+  booktitle    = asplos,
+  year         = {2023},
+}
+
+@article{DBLP:journals/micro/AditS22,
+  author       = {Neil Adit and
+                  Adrian Sampson},
+  title        = {Performance Left on the Table: An Evaluation of Compiler Autovectorization
+                  for {RISC-V}},
+  journal      = micro,
+  year         = {2022},
+}
+
+@inproceedings{DBLP:conf/hpca/LiYNS22,
+  author       = {Zhijing Li and
+                  Yuwei Ye and
+                  Stephen Neuendorffer and
+                  Adrian Sampson},
+  title        = {Compiler-Driven Simulation of Reconfigurable Hardware Accelerators},
+  booktitle    = hpca,
+  year         = {2022},
+}
+
+@inproceedings{DBLP:conf/icse/VanHattumSCS22,
+  author       = {Alexa VanHattum and
+                  Daniel Schwartz{-}Narbonne and
+                  Nathan Chong and
+                  Adrian Sampson},
+  title        = {Verifying Dynamic Trait Objects in Rust},
+  booktitle    = icse-seip,
+  year         = {2022},
+}
 
 @inproceedings{trillium,
     title = {Software-Defined Vector Processing on Manycore Fabrics},


### PR DESCRIPTION
Just adding a few items to our pubs file. I presume this automatically populates [this](https://capra.cs.cornell.edu/pubs/) page. I left out preprints and a couple things that didn't look like full publications:
1. Exploiting Errors for Efficiency: A Survey from Circuits to Applications. [ACM Comput. Surv. 53(3)](https://dblp.org/db/journals/csur/csur53.html#Stanley-Marbell20): 51:1-51:39 (2021)
2. Fifty Years of the International Symposium on Computer Architecture: A Data-Driven Retrospective. [IEEE Micro 43(6)](https://dblp.org/db/journals/micro/micro43.html#SinclairRUSPJPS23): 109-124 (2023)