### PR TITLE
Fix yarn command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To build the site, do something like this:
 
 Or to preview it locally, use:
 
-    $ yarn run serve
+    $ yarn run start
 
 And follow the directions to open it in your browser.
 


### PR DESCRIPTION
I found that the specified command didn't work for me when I ran it locally. Changing it to `start` instead of `serve` did the trick.