### PR TITLE
Add Rio Info to homepage

### DIFF
--- a/src/index.md.njk
+++ b/src/index.md.njk
@@ -61,10 +61,8 @@ can [try Dahlia in your browser](https://capra.cs.cornell.edu/dahlia).
 
 ### [Rio, a Language for Programmable Packet Scheduling][rio]
 
-Prior work has explored programmable packet scheduling on internet routers. 
-Here we are interested in exploring packet schedulers that can live on the FPGA portions of smartNICs,
-and decide how packets get scheduled to hosts that can consume those packets.
-We're developing [Rio][], a domain-specific language for defining packet scheduling policies.
+Prior work has explored programmable packet scheduling on internet routers.  Here we are interested in exploring packet schedulers that can live on the FPGA portions of smartNICs,
+and decide how packets get scheduled to hosts that can consume those packets. We're developing [Rio][], a domain-specific language for defining packet scheduling policies.
 
 
 [rio]: https://github.com/cucapra/packet-scheduling

--- a/src/index.md.njk
+++ b/src/index.md.njk
@@ -62,7 +62,8 @@ can [try Dahlia in your browser](https://capra.cs.cornell.edu/dahlia).
 ### [Rio, a Language for Programmable Packet Scheduling][rio]
 
 Prior work has explored programmable packet scheduling on internet routers.  Here we are interested in exploring packet schedulers that can live on the FPGA portions of smartNICs,
-and decide how packets get scheduled to hosts that can consume those packets. We're developing [Rio][], a domain-specific language for defining packet scheduling policies.
+and decide how packets get scheduled to hosts that can consume those packets. We're developing [Rio][], a domain-specific language for defining packet scheduling policies, and a compiler
+to translate policies down to FPGAs.
 
 
 [rio]: https://github.com/cucapra/packet-scheduling

--- a/src/index.md.njk
+++ b/src/index.md.njk
@@ -57,6 +57,18 @@ can [try Dahlia in your browser](https://capra.cs.cornell.edu/dahlia).
 
 [dahlia]: https://capra.cs.cornell.edu/dahlia
 
+## Software-Defined Networking
+
+### [Rio, a Language for Programmable Packet Scheduling][rio]
+
+Prior work has explored programmable packet scheduling on internet routers. 
+Here we are interested in exploring packet schedulers that can live on the FPGA portions of smartNICs,
+and decide how packets get scheduled to hosts that can consume those packets.
+We're developing [Rio][], a domain-specific language for defining packet scheduling policies.
+
+
+[rio]: https://github.com/cucapra/packet-scheduling
+
 ## Graphics Programming
 
 ### [Gator: Geometry Types][gator]


### PR DESCRIPTION
Adds a header and blurb about Rio to a new section titled 'Software-Defined Networking' on the Capra homepage. Currently links to the Git Repository, but future work can entail developing a more robust webpage for Rio specifically.